### PR TITLE
'lock' object for static list access must also be static

### DIFF
--- a/Logging.Memory/src/Logging.Memory/MemoryLogger.cs
+++ b/Logging.Memory/src/Logging.Memory/MemoryLogger.cs
@@ -10,7 +10,7 @@
     {
         private const int _indentation = 2;
         private readonly string _name;
-        private readonly object _lock = new object();
+        private static object _lock = new object();
         private Func<string, LogLevel, bool> _filter;
 
         private static List<string> logList = new List<string>();


### PR DESCRIPTION
Возможно использовать не-static объект для синхронизации доступа к static-объекту не очень хорошая идея.
