### PR TITLE
Optimize dependencies

### DIFF
--- a/Logging.Memory/src/Logging.Memory/Logging.Memory.csproj
+++ b/Logging.Memory/src/Logging.Memory/Logging.Memory.csproj
@@ -28,9 +28,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
1. `PlatformAbstractions` removed (version 1.1.0) - last updated in 2016, it seems not needed anymore (project compiles successfully)
2. Downgraded `Configuration` and `Logging` abstractions to v2.0, so netcoreapp2.x projects will use "native" versions and not update to 3.x