### PR TITLE
Fixed thread safety of reading log entries

### DIFF
--- a/Logging.Memory/src/Logging.Memory/LogForLevel.cs
+++ b/Logging.Memory/src/Logging.Memory/LogForLevel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Logging.Memory
 {
@@ -10,9 +11,52 @@ namespace Logging.Memory
             logList = new List<(DateTime time, string line)>(maxLogsCount);
         }
 
-        internal int currentLogIndex = 0;
+        readonly ReaderWriterLockSlim rwLock = new ReaderWriterLockSlim();
+        int currentLogIndex = 0;
+        readonly List<(DateTime time, string line)> logList;
 
-        internal List<(DateTime time, string line)> logList;
+        /// <remarks>This method is thread-safe</remarks>
+        public void Append(DateTime time, string line, int maxLogCount)
+        {
+            this.rwLock.EnterWriteLock();
+            try
+            {
+                if (logList.Count < maxLogCount)
+                {
+                    logList.Add((time, line));
+                }
+                else
+                {
+                    logList[currentLogIndex] = (time, line);
+                }
 
+                if (currentLogIndex < maxLogCount - 1)
+                {
+                    currentLogIndex++;
+                }
+                else
+                {
+                    currentLogIndex = 0;
+                }
+            }
+            finally
+            {
+                this.rwLock.ExitWriteLock();
+            }
+        }
+        
+        /// <remarks>This method is thread-safe</remarks>
+        public (DateTime time, string line)[] GetEntries()
+        {
+            this.rwLock.EnterReadLock();
+            try
+            {
+                return logList.ToArray();
+            }
+            finally
+            {
+                this.rwLock.ExitReadLock();
+            }
+        }
     }
 }


### PR DESCRIPTION
One can not read list entries from multiple threads when the list is being updated safely. Some kind of lock is required. I used `ReaderWriterLockSlim`.

Also refactored appending and getting entries into the `LogForLevel` class.